### PR TITLE
카카오 회원가입 수정, 유저 취향 조회 필터 구현

### DIFF
--- a/Api/src/main/java/tify/server/api/auth/controller/AuthController.java
+++ b/Api/src/main/java/tify/server/api/auth/controller/AuthController.java
@@ -5,17 +5,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import tify.server.api.auth.model.request.RegisterRequest;
 import tify.server.api.auth.model.response.AuthResponse;
 import tify.server.api.auth.model.response.OauthLoginLinkResponse;
 import tify.server.api.auth.model.response.OauthTokenResponse;
@@ -75,10 +72,8 @@ public class AuthController {
 
     @Operation(summary = "발급받은 idToken을 통해 회원가입")
     @PostMapping("/oauth/kakao/register")
-    public AuthResponse registerUser(
-            @RequestParam("id_token") String token,
-            @Valid @RequestBody RegisterRequest registerRequest) {
-        return signUpUseCase.registerUserByOICDToken(token, registerRequest);
+    public AuthResponse registerUser(@RequestParam("id_token") String token) {
+        return signUpUseCase.registerUserByOICDToken(token);
     }
 
     @Deprecated

--- a/Api/src/main/java/tify/server/api/auth/service/SignUpUseCase.java
+++ b/Api/src/main/java/tify/server/api/auth/service/SignUpUseCase.java
@@ -4,7 +4,6 @@ package tify.server.api.auth.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import tify.server.api.auth.model.KakaoUserInfoDto;
-import tify.server.api.auth.model.request.RegisterRequest;
 import tify.server.api.auth.model.response.AuthResponse;
 import tify.server.api.auth.model.response.OauthLoginLinkResponse;
 import tify.server.api.auth.model.response.OauthTokenResponse;
@@ -38,11 +37,10 @@ public class SignUpUseCase {
         return new OauthLoginLinkResponse(kakaoOauthHelper.getKaKaoOauthLink(referer));
     }
 
-    public AuthResponse registerUserByOICDToken(
-            String idToken, RegisterRequest registerUserRequest) {
+    public AuthResponse registerUserByOICDToken(String idToken) {
 
         OauthInfo oauthInfo = kakaoOauthHelper.getOauthInfoByIdToken(idToken);
-        User user = userDomainService.registerUser(registerUserRequest.toProfile(), oauthInfo);
+        User user = userDomainService.registerUser(oauthInfo);
 
         return tokenGenerateHelper.execute(user);
     }

--- a/Api/src/main/java/tify/server/api/question/controller/FavorQuestionController.java
+++ b/Api/src/main/java/tify/server/api/question/controller/FavorQuestionController.java
@@ -15,11 +15,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import tify.server.api.config.security.SecurityUtils;
 import tify.server.api.question.model.request.PostFavorAnswerRequest;
 import tify.server.api.question.model.response.RetrieveCategoryIsAnsweredDTO;
 import tify.server.api.question.model.response.RetrieveIsAnsweredByDetailCategoryResponse;
+import tify.server.api.question.model.vo.FavorAnswerInfoVo;
 import tify.server.api.question.model.vo.FavorQuestionInfoVo;
 import tify.server.api.question.service.CreateFavorAnswerUseCase;
+import tify.server.api.question.service.RetrieveFavorAnswerUseCase;
 import tify.server.api.question.service.RetrieveFavorQuestionUseCase;
 import tify.server.api.question.service.RetrieveIsAnsweredUseCase;
 import tify.server.domain.domains.user.domain.SmallCategory;
@@ -35,6 +38,7 @@ public class FavorQuestionController {
     private final RetrieveFavorQuestionUseCase retrieveFavorQuestionUseCase;
     private final RetrieveIsAnsweredUseCase retrieveisAnsweredUseCase;
     private final CreateFavorAnswerUseCase createFavorAnswerUseCase;
+    private final RetrieveFavorAnswerUseCase retrieveFavorAnswerUseCase;
 
     @Operation(summary = "취향 질문 정보 조회")
     @GetMapping
@@ -61,5 +65,14 @@ public class FavorQuestionController {
             @Schema(description = "중분류", implementation = SmallCategory.class) @RequestParam
                     SmallCategory smallCategory) {
         return retrieveisAnsweredUseCase.retrieveIsAnsweredByDetailCategory(smallCategory);
+    }
+
+    @Operation(summary = "SmallCategory(FE기준 중분류) 별 유저 취향 조회")
+    @GetMapping("/answers")
+    public List<FavorAnswerInfoVo> getFavorAnswerBySmallCategory(
+            @Schema(description = "중분류", implementation = SmallCategory.class) @RequestParam
+                    SmallCategory smallCategory) {
+        return retrieveFavorAnswerUseCase.retrieveUserFavorAnswers(
+                SecurityUtils.getCurrentUserId(), smallCategory);
     }
 }

--- a/Api/src/main/java/tify/server/api/question/model/vo/FavorAnswerInfoVo.java
+++ b/Api/src/main/java/tify/server/api/question/model/vo/FavorAnswerInfoVo.java
@@ -1,0 +1,35 @@
+package tify.server.api.question.model.vo;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import tify.server.domain.domains.question.dto.model.FavorAnswerVo;
+import tify.server.domain.domains.user.domain.LargeCategory;
+import tify.server.domain.domains.user.domain.SmallCategory;
+
+@Getter
+@Builder
+public class FavorAnswerInfoVo {
+
+    @Schema(description = "취향 답변의 id", example = "1")
+    private Long answerId;
+
+    @Schema(description = "취향 답변의 대분류", example = "BEAUTY")
+    private LargeCategory largeCategory;
+
+    @Schema(description = "취향 답변의 소분류", example = "FRAGRANCE")
+    private SmallCategory smallCategory;
+
+    @Schema(description = "취향 답변 내용", example = "페리페라")
+    private String answer;
+
+    public static FavorAnswerInfoVo from(FavorAnswerVo favorAnswerVo) {
+        return FavorAnswerInfoVo.builder()
+                .answerId(favorAnswerVo.getAnswerId())
+                .largeCategory(favorAnswerVo.getLargeCategory())
+                .smallCategory(favorAnswerVo.getSmallCategory())
+                .answer(favorAnswerVo.getAnswer())
+                .build();
+    }
+}

--- a/Api/src/main/java/tify/server/api/question/service/CreateFavorAnswerUseCase.java
+++ b/Api/src/main/java/tify/server/api/question/service/CreateFavorAnswerUseCase.java
@@ -1,10 +1,12 @@
 package tify.server.api.question.service;
 
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import tify.server.api.config.security.SecurityUtils;
 import tify.server.api.question.model.request.PostFavorAnswerRequest;
 import tify.server.core.annotation.UseCase;
+import tify.server.domain.domains.question.dto.model.FavorAnswerVo;
 import tify.server.domain.domains.question.service.FavorQuestionDomainService;
 
 @UseCase
@@ -18,5 +20,9 @@ public class CreateFavorAnswerUseCase {
                 SecurityUtils.getCurrentUserId(),
                 body.getCategoryName(),
                 body.getFavorAnswerDtos());
+    }
+
+    public List<FavorAnswerVo> retrieveUserFavorAnswers(String category, Long userId) {
+        return null;
     }
 }

--- a/Api/src/main/java/tify/server/api/question/service/RetrieveFavorAnswerUseCase.java
+++ b/Api/src/main/java/tify/server/api/question/service/RetrieveFavorAnswerUseCase.java
@@ -1,0 +1,23 @@
+package tify.server.api.question.service;
+
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import tify.server.api.question.model.vo.FavorAnswerInfoVo;
+import tify.server.core.annotation.UseCase;
+import tify.server.domain.domains.question.adaptor.FavorAnswerAdaptor;
+import tify.server.domain.domains.user.domain.SmallCategory;
+
+@UseCase
+@RequiredArgsConstructor
+public class RetrieveFavorAnswerUseCase {
+
+    private final FavorAnswerAdaptor favorAnswerAdaptor;
+
+    public List<FavorAnswerInfoVo> retrieveUserFavorAnswers(
+            Long userId, SmallCategory smallCategory) {
+        return favorAnswerAdaptor.searchBySmallCategory(userId, smallCategory).stream()
+                .map(FavorAnswerInfoVo::from)
+                .toList();
+    }
+}

--- a/Domain/src/main/java/tify/server/domain/domains/question/adaptor/FavorAnswerAdaptor.java
+++ b/Domain/src/main/java/tify/server/domain/domains/question/adaptor/FavorAnswerAdaptor.java
@@ -6,9 +6,11 @@ import lombok.RequiredArgsConstructor;
 import tify.server.core.annotation.Adaptor;
 import tify.server.domain.domains.question.domain.FavorAnswer;
 import tify.server.domain.domains.question.dto.model.FavorAnswerCategoryDto;
+import tify.server.domain.domains.question.dto.model.FavorAnswerVo;
 import tify.server.domain.domains.question.exception.FavorAnswerNotFoundException;
 import tify.server.domain.domains.question.repository.FavorAnswerRepository;
 import tify.server.domain.domains.user.domain.DetailCategory;
+import tify.server.domain.domains.user.domain.SmallCategory;
 
 @Adaptor
 @RequiredArgsConstructor
@@ -37,5 +39,9 @@ public class FavorAnswerAdaptor {
         return favorAnswerRepository
                 .searchByCategoryAndNumber(userId, categoryName, number)
                 .orElseThrow(() -> FavorAnswerNotFoundException.EXCEPTION);
+    }
+
+    public List<FavorAnswerVo> searchBySmallCategory(Long userId, SmallCategory smallCategory) {
+        return favorAnswerRepository.getFavorAnswerBySmallCategory(userId, smallCategory);
     }
 }

--- a/Domain/src/main/java/tify/server/domain/domains/question/dto/model/FavorAnswerVo.java
+++ b/Domain/src/main/java/tify/server/domain/domains/question/dto/model/FavorAnswerVo.java
@@ -1,0 +1,22 @@
+package tify.server.domain.domains.question.dto.model;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import tify.server.domain.domains.user.domain.LargeCategory;
+import tify.server.domain.domains.user.domain.SmallCategory;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FavorAnswerVo {
+
+    private Long answerId;
+
+    private LargeCategory largeCategory;
+
+    private SmallCategory smallCategory;
+
+    private String answer;
+}

--- a/Domain/src/main/java/tify/server/domain/domains/question/repository/FavorAnswerCustomRepository.java
+++ b/Domain/src/main/java/tify/server/domain/domains/question/repository/FavorAnswerCustomRepository.java
@@ -5,10 +5,14 @@ import java.util.List;
 import java.util.Optional;
 import tify.server.domain.domains.question.domain.FavorAnswer;
 import tify.server.domain.domains.question.dto.model.FavorAnswerCategoryDto;
+import tify.server.domain.domains.question.dto.model.FavorAnswerVo;
+import tify.server.domain.domains.user.domain.SmallCategory;
 
 public interface FavorAnswerCustomRepository {
 
     List<FavorAnswerCategoryDto> searchToAnswerCategory(Long currentUserId);
 
     Optional<FavorAnswer> searchByCategoryAndNumber(Long userId, String category, Long number);
+
+    List<FavorAnswerVo> getFavorAnswerBySmallCategory(Long userId, SmallCategory smallCategory);
 }

--- a/Domain/src/main/java/tify/server/domain/domains/question/repository/FavorAnswerCustomRepositoryImpl.java
+++ b/Domain/src/main/java/tify/server/domain/domains/question/repository/FavorAnswerCustomRepositoryImpl.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import tify.server.domain.domains.question.domain.FavorAnswer;
 import tify.server.domain.domains.question.dto.model.FavorAnswerCategoryDto;
+import tify.server.domain.domains.question.dto.model.FavorAnswerVo;
+import tify.server.domain.domains.user.domain.SmallCategory;
 
 @RequiredArgsConstructor
 public class FavorAnswerCustomRepositoryImpl implements FavorAnswerCustomRepository {
@@ -54,5 +56,31 @@ public class FavorAnswerCustomRepositoryImpl implements FavorAnswerCustomReposit
                                 favorQuestionCategory.name.eq(category),
                                 favorQuestion.number.eq(number))
                         .fetchOne());
+    }
+
+    @Override
+    public List<FavorAnswerVo> getFavorAnswerBySmallCategory(
+            Long userId, SmallCategory smallCategory) {
+        List<FavorAnswerVo> favorAnswers =
+                queryFactory
+                        .select(
+                                Projections.constructor(
+                                        FavorAnswerVo.class,
+                                        favorAnswer.id,
+                                        favorQuestionCategory.largeCategory,
+                                        favorQuestionCategory.smallCategory,
+                                        favorAnswer.answerContent))
+                        .from(favorAnswer)
+                        .join(favorQuestion)
+                        .on(favorAnswer.favorQuestion.id.eq(favorQuestion.id))
+                        .join(favorQuestionCategory)
+                        .on(favorQuestion.favorQuestionCategory.id.eq(favorQuestionCategory.id))
+                        .where(
+                                favorQuestionCategory
+                                        .smallCategory
+                                        .eq(smallCategory)
+                                        .and(favorAnswer.userId.eq(userId)))
+                        .fetch();
+        return favorAnswers;
     }
 }

--- a/Domain/src/main/java/tify/server/domain/domains/user/domain/User.java
+++ b/Domain/src/main/java/tify/server/domain/domains/user/domain/User.java
@@ -62,6 +62,11 @@ public class User extends AbstractTimeStamp {
         this.expoToken = expoToken;
     }
 
+    @Builder
+    public User(OauthInfo oauthInfo) {
+        this.oauthInfo = oauthInfo;
+    }
+
     public void onBoarding(
             String username,
             String userId,

--- a/Domain/src/main/java/tify/server/domain/domains/user/service/UserDomainService.java
+++ b/Domain/src/main/java/tify/server/domain/domains/user/service/UserDomainService.java
@@ -22,10 +22,10 @@ public class UserDomainService {
     private final UserRepository userRepository;
 
     @Transactional
-    public User registerUser(Profile profile, OauthInfo oauthInfo) {
+    public User registerUser(OauthInfo oauthInfo) {
         userValidator.isNewUser(oauthInfo);
 
-        User user = User.builder().profile(profile).oauthInfo(oauthInfo).build();
+        User user = User.builder().oauthInfo(oauthInfo).build();
         return userAdaptor.save(user);
     }
 


### PR DESCRIPTION
## 📝 PR Summary

<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->
- 카카오 회원가입 수정(회원가입 시 입력 필요 없는 Request Body 삭제)
- 유저 취향 조회 필터 구현(취향 API에 중분류 별 유저의 취향 답변 조회하는 API추가)

#### 🌲 Working Branch

<!-- 예시) hotfix/price_comma -->

feat/65-register-filter-fix

#### 🌲 TODOs

<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues

<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
#65 
