### PR TITLE
[FIX] 유저 검색 시 온전한 ID로 검색하도록 수정

### DIFF
--- a/Api/src/main/java/tify/server/api/user/controller/UserController.java
+++ b/Api/src/main/java/tify/server/api/user/controller/UserController.java
@@ -26,6 +26,7 @@ import tify.server.domain.domains.user.domain.LargeCategory;
 import tify.server.domain.domains.user.dto.condition.UserCondition;
 import tify.server.domain.domains.user.dto.model.GetNeighborApplicationDTO;
 import tify.server.domain.domains.user.dto.model.RetrieveNeighborDTO;
+import tify.server.api.user.model.dto.vo.MutualFriendsVo;
 
 @SecurityRequirement(name = "access-token")
 @RestController
@@ -48,6 +49,7 @@ public class UserController {
     private final AcceptanceNeighborApplicationUseCase acceptanceNeighborApplicationUseCase;
     private final RejectNeighborApplicationUseCase rejectNeighborApplicationUseCase;
     private final RetrieveUserListUseCase retrieveUserListUseCase;
+    private final RetrieveMutualFriendsUseCase retrieveMutualFriendsUseCase;
 
     // userId를 pathvariable로 받아서 그 해당 유저의 profile 정보를 리턴하기.
     @Operation(summary = "유저 정보 조회")
@@ -172,5 +174,11 @@ public class UserController {
             @ParameterObject @PageableDefault Pageable pageable,
             @ParameterObject UserCondition condition) {
         return SliceResponse.of(retrieveUserListUseCase.execute(pageable, condition));
+    }
+
+    @Operation(summary = "함께 아는 친구의 수를 조회합니다.")
+    @GetMapping("/neighbors/mutual/{toUserId}")
+    public MutualFriendsVo getMutualFriendNum(@PathVariable Long toUserId) {
+        return retrieveMutualFriendsUseCase.execute(toUserId);
     }
 }

--- a/Api/src/main/java/tify/server/api/user/controller/UserController.java
+++ b/Api/src/main/java/tify/server/api/user/controller/UserController.java
@@ -17,6 +17,7 @@ import tify.server.api.user.model.dto.request.PutUserProfileRequest;
 import tify.server.api.user.model.dto.request.UserOnBoardingRequest;
 import tify.server.api.user.model.dto.response.OnBoardingStatusResponse;
 import tify.server.api.user.model.dto.vo.MutualFriendsVo;
+import tify.server.api.user.model.dto.vo.UserSearchInfoVo;
 import tify.server.api.user.service.*;
 import tify.server.api.user.service.CreateNeighborUseCase;
 import tify.server.domain.common.vo.UserFavorVo;
@@ -170,7 +171,7 @@ public class UserController {
 
     @Operation(summary = "유저를 검색합니다.")
     @GetMapping
-    public SliceResponse<UserInfoVo> getUsers(
+    public SliceResponse<UserSearchInfoVo> getUsers(
             @ParameterObject @PageableDefault Pageable pageable,
             @ParameterObject UserCondition condition) {
         return SliceResponse.of(retrieveUserListUseCase.execute(pageable, condition));

--- a/Api/src/main/java/tify/server/api/user/controller/UserController.java
+++ b/Api/src/main/java/tify/server/api/user/controller/UserController.java
@@ -16,6 +16,7 @@ import tify.server.api.user.model.dto.request.PatchNeighborsOrdersRequest;
 import tify.server.api.user.model.dto.request.PutUserProfileRequest;
 import tify.server.api.user.model.dto.request.UserOnBoardingRequest;
 import tify.server.api.user.model.dto.response.OnBoardingStatusResponse;
+import tify.server.api.user.model.dto.vo.MutualFriendsVo;
 import tify.server.api.user.service.*;
 import tify.server.api.user.service.CreateNeighborUseCase;
 import tify.server.domain.common.vo.UserFavorVo;
@@ -26,7 +27,6 @@ import tify.server.domain.domains.user.domain.LargeCategory;
 import tify.server.domain.domains.user.dto.condition.UserCondition;
 import tify.server.domain.domains.user.dto.model.GetNeighborApplicationDTO;
 import tify.server.domain.domains.user.dto.model.RetrieveNeighborDTO;
-import tify.server.api.user.model.dto.vo.MutualFriendsVo;
 
 @SecurityRequirement(name = "access-token")
 @RestController

--- a/Api/src/main/java/tify/server/api/user/model/dto/vo/MutualFriendsVo.java
+++ b/Api/src/main/java/tify/server/api/user/model/dto/vo/MutualFriendsVo.java
@@ -1,0 +1,27 @@
+package tify.server.api.user.model.dto.vo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MutualFriendsVo {
+
+    @Schema(description = "현재 내 id")
+    private Long fromUserId;
+
+    @Schema(description = "검색으로 찾은 유저의 id")
+    private Long toUserId;
+
+    @Schema(description = "함께 아는 친구의 수")
+    private long mutualFriendsCount;
+
+    public static MutualFriendsVo of(Long fromUserId, Long toUserId, long mutualFriendsCount) {
+        return MutualFriendsVo.builder()
+            .fromUserId(fromUserId)
+            .toUserId(toUserId)
+            .mutualFriendsCount(mutualFriendsCount)
+            .build();
+    }
+}

--- a/Api/src/main/java/tify/server/api/user/model/dto/vo/MutualFriendsVo.java
+++ b/Api/src/main/java/tify/server/api/user/model/dto/vo/MutualFriendsVo.java
@@ -1,5 +1,6 @@
 package tify.server.api.user.model.dto.vo;
 
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,9 +20,9 @@ public class MutualFriendsVo {
 
     public static MutualFriendsVo of(Long fromUserId, Long toUserId, long mutualFriendsCount) {
         return MutualFriendsVo.builder()
-            .fromUserId(fromUserId)
-            .toUserId(toUserId)
-            .mutualFriendsCount(mutualFriendsCount)
-            .build();
+                .fromUserId(fromUserId)
+                .toUserId(toUserId)
+                .mutualFriendsCount(mutualFriendsCount)
+                .build();
     }
 }

--- a/Api/src/main/java/tify/server/api/user/model/dto/vo/MutualFriendsVo.java
+++ b/Api/src/main/java/tify/server/api/user/model/dto/vo/MutualFriendsVo.java
@@ -10,15 +10,15 @@ import lombok.Getter;
 public class MutualFriendsVo {
 
     @Schema(description = "현재 내 id")
-    private Long fromUserId;
+    private final Long fromUserId;
 
     @Schema(description = "검색으로 찾은 유저의 id")
-    private Long toUserId;
+    private final Long toUserId;
 
     @Schema(description = "함께 아는 친구의 수")
-    private long mutualFriendsCount;
+    private final int mutualFriendsCount;
 
-    public static MutualFriendsVo of(Long fromUserId, Long toUserId, long mutualFriendsCount) {
+    public static MutualFriendsVo of(Long fromUserId, Long toUserId, int mutualFriendsCount) {
         return MutualFriendsVo.builder()
                 .fromUserId(fromUserId)
                 .toUserId(toUserId)

--- a/Api/src/main/java/tify/server/api/user/model/dto/vo/UserSearchInfoVo.java
+++ b/Api/src/main/java/tify/server/api/user/model/dto/vo/UserSearchInfoVo.java
@@ -1,0 +1,37 @@
+package tify.server.api.user.model.dto.vo;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import tify.server.domain.domains.user.domain.User;
+
+@Getter
+@Builder
+public class UserSearchInfoVo {
+
+    @Schema(description = "검색하여 찾은 유저의 pk")
+    private final Long id;
+
+    @Schema(description = "검색하여 찾은 유저의 id")
+    private final String userId;
+
+    @Schema(description = "검색하여 찾은 유저의 이름")
+    private final String userName;
+
+    @Schema(description = "검색하여 찾은 유저의 프로필 이미지")
+    private final String imgUrl;
+
+    @Schema(description = "검색하여 찾은 친구와 함께 아는 친구 수")
+    private final int mutualFriends;
+
+    public static UserSearchInfoVo of(User user, int mutualFriends) {
+        return UserSearchInfoVo.builder()
+                .id(user.getId())
+                .userId(user.getUserId())
+                .userName(user.getProfile().getUserName())
+                .imgUrl(user.getProfile().getThumbNail())
+                .mutualFriends(mutualFriends)
+                .build();
+    }
+}

--- a/Api/src/main/java/tify/server/api/user/service/RetrieveMutualFriendsUseCase.java
+++ b/Api/src/main/java/tify/server/api/user/service/RetrieveMutualFriendsUseCase.java
@@ -7,30 +7,31 @@ import org.springframework.transaction.annotation.Transactional;
 import tify.server.api.config.security.SecurityUtils;
 import tify.server.api.user.model.dto.vo.MutualFriendsVo;
 import tify.server.core.annotation.UseCase;
+import tify.server.domain.domains.user.adaptor.NeighborAdaptor;
 import tify.server.domain.domains.user.domain.Neighbor;
-import tify.server.domain.domains.user.repository.NeighborRepository;
 
 @UseCase
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class RetrieveMutualFriendsUseCase {
 
-    private final NeighborRepository neighborRepository;
+    private final NeighborAdaptor neighborAdaptor;
 
     public MutualFriendsVo execute(Long toUserId) {
         Long userId = SecurityUtils.getCurrentUserId();
 
         List<Long> myNeighbors =
-                neighborRepository.findAllByFromUserId(userId).stream()
+                neighborAdaptor.queryAllByFromUserId(userId).stream()
                         .map(Neighbor::getToUserId)
                         .toList();
 
         List<Long> findUserNeighbors =
-                neighborRepository.findAllByFromUserId(toUserId).stream()
+                neighborAdaptor.queryAllByFromUserId(toUserId).stream()
                         .map(Neighbor::getToUserId)
                         .toList();
 
-        long mutualFriendsCount = myNeighbors.stream().filter(findUserNeighbors::contains).count();
+        int mutualFriendsCount =
+                (int) myNeighbors.stream().filter(findUserNeighbors::contains).count();
 
         return MutualFriendsVo.of(userId, toUserId, mutualFriendsCount);
     }

--- a/Api/src/main/java/tify/server/api/user/service/RetrieveMutualFriendsUseCase.java
+++ b/Api/src/main/java/tify/server/api/user/service/RetrieveMutualFriendsUseCase.java
@@ -1,0 +1,36 @@
+package tify.server.api.user.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import tify.server.api.config.security.SecurityUtils;
+import tify.server.core.annotation.UseCase;
+import tify.server.domain.domains.user.domain.Neighbor;
+import tify.server.domain.domains.user.repository.NeighborRepository;
+import tify.server.api.user.model.dto.vo.MutualFriendsVo;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RetrieveMutualFriendsUseCase {
+
+    private final NeighborRepository neighborRepository;
+
+    public MutualFriendsVo execute(Long toUserId) {
+        Long userId = SecurityUtils.getCurrentUserId();
+
+        List<Long> myNeighbors = neighborRepository.findAllByFromUserId(userId)
+            .stream()
+            .map(Neighbor::getToUserId)
+            .toList();
+
+        List<Long> findUserNeighbors = neighborRepository.findAllByFromUserId(toUserId)
+            .stream()
+            .map(Neighbor::getToUserId)
+            .toList();
+
+        long mutualFriendsCount = myNeighbors.stream().filter(findUserNeighbors::contains).count();
+
+        return MutualFriendsVo.of(userId, toUserId, mutualFriendsCount);
+    }
+}

--- a/Api/src/main/java/tify/server/api/user/service/RetrieveMutualFriendsUseCase.java
+++ b/Api/src/main/java/tify/server/api/user/service/RetrieveMutualFriendsUseCase.java
@@ -1,13 +1,14 @@
 package tify.server.api.user.service;
 
+
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import tify.server.api.config.security.SecurityUtils;
+import tify.server.api.user.model.dto.vo.MutualFriendsVo;
 import tify.server.core.annotation.UseCase;
 import tify.server.domain.domains.user.domain.Neighbor;
 import tify.server.domain.domains.user.repository.NeighborRepository;
-import tify.server.api.user.model.dto.vo.MutualFriendsVo;
 
 @UseCase
 @RequiredArgsConstructor
@@ -19,15 +20,15 @@ public class RetrieveMutualFriendsUseCase {
     public MutualFriendsVo execute(Long toUserId) {
         Long userId = SecurityUtils.getCurrentUserId();
 
-        List<Long> myNeighbors = neighborRepository.findAllByFromUserId(userId)
-            .stream()
-            .map(Neighbor::getToUserId)
-            .toList();
+        List<Long> myNeighbors =
+                neighborRepository.findAllByFromUserId(userId).stream()
+                        .map(Neighbor::getToUserId)
+                        .toList();
 
-        List<Long> findUserNeighbors = neighborRepository.findAllByFromUserId(toUserId)
-            .stream()
-            .map(Neighbor::getToUserId)
-            .toList();
+        List<Long> findUserNeighbors =
+                neighborRepository.findAllByFromUserId(toUserId).stream()
+                        .map(Neighbor::getToUserId)
+                        .toList();
 
         long mutualFriendsCount = myNeighbors.stream().filter(findUserNeighbors::contains).count();
 

--- a/Domain/src/main/java/tify/server/domain/domains/user/repository/UserCustomRepositoryImpl.java
+++ b/Domain/src/main/java/tify/server/domain/domains/user/repository/UserCustomRepositoryImpl.java
@@ -28,7 +28,7 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
                         .fetchJoin()
                         .leftJoin(user.onBoardingStatus, userOnBoardingStatus)
                         .fetchJoin()
-                        .where(userIdContains(userCondition.getUserId()))
+                        .where(userIdEquals(userCondition.getUserId()))
                         .orderBy(user.id.desc())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize() + 1)
@@ -37,7 +37,7 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
         return SliceUtil.valueOf(contents, pageable);
     }
 
-    private BooleanExpression userIdContains(String userId) {
-        return (userId != null) ? user.userId.contains(userId) : null;
+    private BooleanExpression userIdEquals(String userId) {
+        return (userId != null) ? user.userId.eq(userId) : null;
     }
 }


### PR DESCRIPTION
## 📝 PR Summary

<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->
유저 검색 시 온전한 ID로 검색하도록 수정

#### 🌲 Working Branch

<!-- 예시) hotfix/price_comma -->
refactor/75-user-search

#### 🌲 TODOs

<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->
- 유저가 입력한 ID를 contains한 ID를 가진 유저를 조회하던 기존의 방식을
- 유저가 입력한 ID와 eq한 ID를 가진 유저를 조회하도록 변경

### Related Issues

<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
close #75 
